### PR TITLE
Fix common errors.

### DIFF
--- a/src/mtl_headers/mtl/linalg_vec.h
+++ b/src/mtl_headers/mtl/linalg_vec.h
@@ -116,6 +116,7 @@ public:
   typedef difference_type Vec_difference_type;
   typedef iterator Vec_iterator;
   typedef const_iterator Vec_const_iterator;
+  typedef value_type Vec_value_type;
 
   class IndexArray {
   public:

--- a/src/utils/toolbox/database/HDFDatabase.cc
+++ b/src/utils/toolbox/database/HDFDatabase.cc
@@ -686,7 +686,7 @@ void HDFDatabase::putBoolArray(
    herr_t errf;
    if (nelements > 0) {
 
-      hsize_t dim[] = {nelements};
+      hsize_t dim[] = {(unsigned long long)nelements};
       hid_t space = H5Screate_simple(1, dim, NULL);
 #ifdef ASSERT_HDF5_RETURN_VALUES
       assert( space >= 0 );
@@ -1233,7 +1233,7 @@ void HDFDatabase::putDoubleArray(
    herr_t errf;
    if (nelements > 0) {
 
-      hsize_t dim[] = {nelements};
+      hsize_t dim[] = {(unsigned long long)nelements};
       hid_t space = H5Screate_simple(1, dim, NULL);
 #ifdef ASSERT_HDF5_RETURN_VALUES
       assert( space >= 0 );
@@ -1478,7 +1478,7 @@ void HDFDatabase::putFloatArray(
    herr_t errf;
    if (nelements > 0) {
 
-      hsize_t dim[] = {nelements};
+      hsize_t dim[] = {(unsigned long long)nelements};
       hid_t space = H5Screate_simple(1, dim, NULL);
 #ifdef ASSERT_HDF5_RETURN_VALUES
       assert( space >= 0 );
@@ -1722,7 +1722,7 @@ void HDFDatabase::putIntegerArray(
    herr_t errf;
    if (nelements > 0) {
 
-      hsize_t dim[] = {nelements};
+      hsize_t dim[] = {(unsigned long long)nelements};
       hid_t space = H5Screate_simple(1, dim, NULL);
 #ifdef ASSERT_HDF5_RETURN_VALUES
       assert(space >= 0);
@@ -1998,7 +1998,7 @@ void HDFDatabase::putStringArray(
       assert( errf >= 0 );
 #endif
 
-      hsize_t dim[] = {nelements};
+      hsize_t dim[] = {(unsigned long long)nelements};
       hid_t space = H5Screate_simple(1, dim, NULL);
 #ifdef ASSERT_HDF5_RETURN_VALUES
       assert( space >= 0 );


### PR DESCRIPTION
Hello. I found two errors building `aspa`, so suggest source fixes.
Could you check if it is the right fix?

* defined new member 'Vec_value_type' in 'self' namespace.
```
     460    In file included from ../src/mtl_headers/mtl/matrix_implementation.h:27:
  >> 461    ../src/mtl_headers/mtl/linalg_vec.h:135:21: error: no member named 'Vec_value_type
            ' in 'linalg_vec<RepType, RepPtr, NN>'
     462            while (*i == self::Vec_value_type(0)) ++i;
     463                         ~~~~~~^
```
I defined `Vec_value_type` as a member of `linalg_vec` namespace with reference to other header file `src/mtl_headers/mtl/dense1D.h`.

* fix narrowing error.
```
  >> 915    ../src/utils/toolbox/database/HDFDatabase.cc:689:24: error: non-con
            stant-expression cannot be narrowed from type 'int' to 'hsize_t' (a
            ka 'unsigned long long') in initializer list [-Wc++11-narrowing]
     916          hsize_t dim[] = {nelements};
     917                           ^~~~~~~~~
```
I did a typecast for `nelements` to 'unsigned long long'.